### PR TITLE
Support failure for bad SDK key

### DIFF
--- a/FeatureHubSDK/EdgeFeatureHubConfig.cs
+++ b/FeatureHubSDK/EdgeFeatureHubConfig.cs
@@ -37,6 +37,19 @@ namespace FeatureHubSDK
 
     void AddAnalyticCollector(IAnalyticsCollector collector);
   }
+  
+  public class FeatureHubKeyInvalidException : Exception
+  {
+    public FeatureHubKeyInvalidException(string message)
+      : base(message)
+    {
+    }
+
+    public FeatureHubKeyInvalidException(string message, Exception innerException)
+      : base(message, innerException)
+    {
+    }
+  }
 
   public class EdgeFeatureHubConfig : IFeatureHubConfig
   {
@@ -46,6 +59,11 @@ namespace FeatureHubSDK
     public EdgeFeatureHubConfig(string edgeUrl, string sdkKey)
     {
       _serverEvaluation = sdkKey != null && !sdkKey.Contains("*"); // two part keys are server evaluated
+
+      if (!sdkKey.Contains("/"))
+      {
+        throw new FeatureHubKeyInvalidException($"The SDK key `{sdkKey}` is invalid");
+      }
 
       if (edgeUrl.EndsWith("/"))
       {

--- a/FeatureHubSDK/FeatureHubSDK.csproj
+++ b/FeatureHubSDK/FeatureHubSDK.csproj
@@ -16,9 +16,9 @@
         <RepositoryUrl>https://github.com/featurehub-io/featurehub-dotnet-sdk</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>FeatureFlags FeatureToggles SDK Flags Toggles RemoteConfig</PackageTags>
-        <PackageReleaseNotes>2.2.0 - updates for caching support, update min dependencies.</PackageReleaseNotes>
-        <Version>2.2.0</Version>
-        <PackageVersion>2.2.0</PackageVersion>
+        <PackageReleaseNotes>2.3.0 - check valid keys and stop calling server on failure.</PackageReleaseNotes>
+        <Version>2.3.0</Version>
+        <PackageVersion>2.3.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/FeatureHubTest/ConfigTest.cs
+++ b/FeatureHubTest/ConfigTest.cs
@@ -9,15 +9,21 @@ namespace FeatureHubTest
     [Test]
     public void EnsureConfigCorrectlyDeterminesUrl()
     {
-      var cfg = new EdgeFeatureHubConfig("http://localhost:80/", "123*123");
+      var cfg = new EdgeFeatureHubConfig("http://localhost:80/", "id/123*123");
       Assert.IsTrue(!cfg.ServerEvaluation);
-      Assert.AreEqual("http://localhost:80/features/123*123", cfg.Url);
+      Assert.AreEqual("http://localhost:80/features/id/123*123", cfg.Url);
 
-      cfg = new EdgeFeatureHubConfig("http://localhost:80", "123");
+      cfg = new EdgeFeatureHubConfig("http://localhost:80", "id/123");
       Assert.IsTrue(cfg.ServerEvaluation);
-      Assert.AreEqual("http://localhost:80/features/123", cfg.Url);
+      Assert.AreEqual("http://localhost:80/features/id/123", cfg.Url);
     }
 
 
+    [Test]
+    public void InvalidKeyStructureFails()
+    {
+      Assert.Throws<FeatureHubSDK.FeatureHubKeyInvalidException>(() => 
+        new EdgeFeatureHubConfig("http://localhost:80/", "123*123"));
+    } 
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Details about what general features are available in FeatureHub SDKs are [availa
 
 ## Changelog
 
+- 2.3.0 - Support for preventing badly formatted API keys from being passed in. Support for API keys and cause 4xx errors
+to stop polling. Support for overriding the number of backoff attempts made (`FEATUREHUB_BACKOFF_RETRY_LIMIT` - defaults to 100),
+and delay retry timeout (was zero, now 10s, controlled by `FEATUREHUB_DELAY_RETRY_MS`).
 - 2.2.0 - FeatureHub 1.5.9 support - supporting Fastly integration, server side polling period control, stale environments.
  We have upgraded to the 6.0.1 OpenAPI compiler, but gone no further because it generates code that does not work.
 - 2.1.5 - FeatureHub 1.5.6 is not returning the name of the feature and this is causing the 2.1.4 to version to break.


### PR DESCRIPTION
The default operation of the EventSource SDK is to continually poll, and the library does not provide for absolute failure without an error handler telling it to stop.

If the server sends 4xx errors, it should stop, absolutely, and not retry.